### PR TITLE
Fix packed imports and typings

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+polyfill/index.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastly/performance-observer-polyfill",
-  "version": "1.0.1-0",
+  "version": "1.0.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastly/performance-observer-polyfill",
-  "version": "1.0.0",
+  "version": "1.0.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastly/performance-observer-polyfill",
-  "version": "1.0.1-0",
+  "version": "1.0.2-0",
   "main": "dist/index.js",
   "files": [
     "src",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastly/performance-observer-polyfill",
-  "version": "1.0.0",
+  "version": "1.0.1-0",
   "main": "dist/index.js",
   "files": [
     "src",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@fastly/performance-observer-polyfill",
   "version": "1.0.0",
   "main": "dist/index.js",
-  "module": "src/index.js",
   "files": [
     "src",
     "dist",

--- a/polyfill/index.ts
+++ b/polyfill/index.ts
@@ -1,3 +1,3 @@
 import PerformanceObserver from "../src/index";
-const ctx = window || self;
+const ctx = self;
 if (!ctx.PerformanceObserver) ctx.PerformanceObserver = PerformanceObserver;

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,12 +1,18 @@
-interface PollingPerformanceObserver extends PerformanceObserver {
-  buffer: Set<PerformanceEntry>;
-  callback: PerformanceObserverCallback;
-  entryTypes: string[];
+declare namespace PollingPerformanceObserver {
+  interface PollingPerformanceObserver extends PerformanceObserver {
+    buffer: Set<PerformanceEntry>;
+    callback: PerformanceObserverCallback;
+    entryTypes: string[];
+  }
+
+  interface PerformanceObserverTaskQueueOptions {
+    registeredObservers?: Set<PollingPerformanceObserver>;
+    processedEntries?: Set<PerformanceEntry>;
+    interval?: number;
+    context?: any;
+  }
 }
 
-interface PerformanceObserverTaskQueueOptions {
-  registeredObservers?: Set<PollingPerformanceObserver>;
-  processedEntries?: Set<PerformanceEntry>;
-  interval?: number;
-  context?: any;
-}
+declare const PollingPerformanceObserver: typeof PerformanceObserver;
+
+export default PollingPerformanceObserver;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 /* global PerformanceObserver */
 import PollingPerformanceObserver from "./observer";
 const isSupported =
-  "PerformanceObserver" in window && typeof PerformanceObserver === "function";
+  "PerformanceObserver" in self && typeof PerformanceObserver === "function";
 
 export default isSupported ? PerformanceObserver : PollingPerformanceObserver;

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -12,6 +12,12 @@ const isValidType = (type: string): boolean =>
 
 const globalTaskQueue = new PerformanceObserverTaskQueue();
 
+interface PollingPerformanceObserver extends PerformanceObserver {
+  buffer: Set<PerformanceEntry>;
+  callback: PerformanceObserverCallback;
+  entryTypes: string[];
+}
+
 class PerformanceObserver implements PollingPerformanceObserver {
   public callback: PerformanceObserverCallback;
   public buffer: Set<PerformanceEntry>;

--- a/src/task-queue.spec.ts
+++ b/src/task-queue.spec.ts
@@ -1,5 +1,6 @@
 import PollingPerformanceObserverTaskQueue from "./task-queue";
 import PerformanceObserverEntryList from "./entry-list";
+import PollingPerformanceObserver from "./observer";
 import entries from "./fixtures/entries";
 
 const entriesFixture = entries as PerformanceEntry[];

--- a/src/task-queue.ts
+++ b/src/task-queue.ts
@@ -1,4 +1,12 @@
 import EntryList from "./entry-list";
+import PollingPerformanceObserver from "./observer";
+
+interface PerformanceObserverTaskQueueOptions {
+  registeredObservers?: Set<PollingPerformanceObserver>;
+  processedEntries?: Set<PerformanceEntry>;
+  interval?: number;
+  context?: any;
+}
 
 class PollingPerformanceObserverTaskQueue {
   private registeredObservers: Set<PollingPerformanceObserver>;

--- a/src/task-queue.ts
+++ b/src/task-queue.ts
@@ -11,7 +11,7 @@ class PollingPerformanceObserverTaskQueue {
     registeredObservers = new Set(),
     processedEntries = new Set(),
     interval = 100,
-    context = window || self
+    context = self
   }: PerformanceObserverTaskQueueOptions = {}) {
     this.registeredObservers = registeredObservers;
     this.processedEntries = processedEntries;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -32,6 +32,7 @@ module.exports = {
     library: 'PerformanceOberserverPolyfill',
     libraryTarget: 'umd',
     filename: 'index.js',
-    path: path.resolve(__dirname, 'dist')
+    path: path.resolve(__dirname, 'dist'),
+    globalObject: 'this'
   }
 };


### PR DESCRIPTION
### TL;DR
Fixes the exported `@types` ensuring that it actually defined as a module and exports the correct types, which allows them to be consumed properly. Also removes `module` declaration from `package.json` as the source is TypeScript and thus can only be imported in TS projects, the library also doesn't benefit from tree shaking so not a concern to only publish the compiled bundle.