### PR TITLE
Add readonly supportedEntryTypes property

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,7 +1,12 @@
 import PerformanceObserverTaskQueue from "./task-queue";
 import EntryList from "./entry-list";
 
-const VALID_TYPES = ["mark", "measure", "navigation", "resource"];
+const VALID_TYPES: readonly string[] = [
+  "mark",
+  "measure",
+  "navigation",
+  "resource"
+];
 const ERRORS = {
   "no-entry-types": `Failed to execute 'observe' on 'PerformanceObserver': required member entryTypes is undefined.`,
   "invalid-entry-types": `Failed to execute 'observe' on 'PerformanceObserver': A Performance Observer MUST have at least one valid entryType in its entryTypes attribute.`
@@ -22,6 +27,7 @@ class PerformanceObserver implements PollingPerformanceObserver {
   public callback: PerformanceObserverCallback;
   public buffer: Set<PerformanceEntry>;
   public entryTypes: string[] = [];
+  public static readonly supportedEntryTypes = VALID_TYPES;
   private taskQueue: PerformanceObserverTaskQueue;
 
   public constructor(


### PR DESCRIPTION
### TL;DR
Fixes #4 by adding a public readonly property `supportedEntryTypes` to the `PollingPerformanceObserver` class.

### Why?
It is part of the spec (see [here](https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute) but only has experimental support in a few browsers,  however it seems it was added to TypeScript definition for `PerformanceObserver` in 3.7.2.