### PR TITLE
PerformanceObserverEntryList should not extend Array

### DIFF
--- a/src/entry-list.ts
+++ b/src/entry-list.ts
@@ -1,9 +1,7 @@
-export default class EntryList extends Array<PerformanceEntry>
-  implements PerformanceEntryList {
+export default class EntryList implements PerformanceObserverEntryList {
   private _entries: PerformanceEntry[];
 
   public constructor(entries: PerformanceEntry[]) {
-    super(...entries);
     this._entries = entries;
   }
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,5 +1,4 @@
 import PerformanceObserverTaskQueue from "./task-queue";
-import EntryList from "./entry-list";
 
 const VALID_TYPES: readonly string[] = [
   "mark",
@@ -82,8 +81,7 @@ class PerformanceObserver implements PollingPerformanceObserver {
   }
 
   public takeRecords(): PerformanceEntryList {
-    const entries = Array.from(this.buffer);
-    return new EntryList(entries);
+    return Array.from(this.buffer);
   }
 }
 


### PR DESCRIPTION
*Note:* This is a PR into #17 until hat is merged. 

### TL;DR
Fixes a hidden bug with current implementation of the library which had the `EntryList` implementation extend the native `Array` and incorrectly suggest that it implements the `PerformanceEntryList` type and not the correct `PerformanceObserverEntryList` interface.

It seems this bug was obscured from the compiled output via Webpack/babel, which seems to treat compilation of `Class foo extends Array` (and all its inherent problems) differently that theTypeScript compiler, and was exposed when we removed those tools in #17 and broke upstream test suites.

Fortunately, per the spec, [`PerformanceObserverEntryList`](https://w3c.github.io/performance-timeline/#performanceobserverentrylist-interface) doesn't need to be an array like object and just needs to implement the interface, which we already were. This PR fixes both of these issues. 